### PR TITLE
Fix Alembic config and migrations

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -6,21 +6,19 @@ import os
 import sys
 from logging.config import fileConfig
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import create_engine, pool
 from alembic import context
 from festserve_api.database import DATABASE_URL
 
 
 # Add backend/src to the path so ``from festserve_api.models import Base`` works
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
 
-#from festserve_api.models import Base
+# from festserve_api.models import Base
 from festserve_api.database import Base
 
-
-print("Base metadata tables:", Base.metadata.tables)
 
 # Alembic Config object, provides access to values within the .ini file.
 config = context.config
@@ -32,6 +30,7 @@ fileConfig(config.config_file_name)
 
 # Metadata for 'autogenerate' support.
 target_metadata = Base.metadata
+
 
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode."""
@@ -51,9 +50,8 @@ def run_migrations_offline() -> None:
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
 
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
-        prefix="sqlalchemy.",
+    connectable = create_engine(
+        DATABASE_URL,
         poolclass=pool.NullPool,
     )
 
@@ -68,4 +66,3 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-

--- a/backend/alembic/versions/2e446586fcf8_make_scanner_assigned_stall_id_nullable.py
+++ b/backend/alembic/versions/2e446586fcf8_make_scanner_assigned_stall_id_nullable.py
@@ -1,30 +1,30 @@
 """make scanner.assigned_stall_id nullable
 
 Revision ID: 2e446586fcf8
-Revises: 
+Revises:
 Create Date: 2025-07-06 18:15:06.987479
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '2e446586fcf8'
+revision: str = "2e446586fcf8"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.alter_column('scanner_users', 'assigned_stall_id', nullable=True)
+    op.alter_column("scanner_users", "assigned_stall_id", nullable=True)
     """Upgrade schema."""
     pass
 
 
 def downgrade() -> None:
-    op.alter_column('scanner_users', 'assigned_stall_id', nullable=False)
+    op.alter_column("scanner_users", "assigned_stall_id", nullable=False)
     """Downgrade schema."""
     pass

--- a/backend/alembic/versions/d28ca03a8465_add_password_hash_to_advertisers.py
+++ b/backend/alembic/versions/d28ca03a8465_add_password_hash_to_advertisers.py
@@ -5,22 +5,27 @@ Revises: 2e446586fcf8
 Create Date: 2025-07-06 18:37:02.636037
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = 'd28ca03a8465'
-down_revision: Union[str, None] = '2e446586fcf8'
+revision: str = "d28ca03a8465"
+down_revision: Union[str, None] = "2e446586fcf8"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+
 def upgrade():
     op.add_column(
-        'advertisers',
-        sa.Column('password_hash', sa.String(), nullable=False, server_default=sa.text("''"))
+        "advertisers",
+        sa.Column(
+            "password_hash", sa.String(), nullable=False, server_default=sa.text("''")
+        ),
     )
-    op.alter_column('advertisers', 'password_hash', server_default=None)
+    op.alter_column("advertisers", "password_hash", server_default=None)
+
 
 def downgrade():
-    op.drop_column('advertisers', 'password_hash')
+    op.drop_column("advertisers", "password_hash")

--- a/backend/drop_alembic_version.py
+++ b/backend/drop_alembic_version.py
@@ -1,11 +1,7 @@
 import psycopg2
 
 conn = psycopg2.connect(
-    dbname="festserve",
-    user="festserve",
-    password="festserve",
-    host="localhost",
-    port=5432
+    dbname="festserve", user="festserve", password="festserve", host="db", port=5432
 )
 cur = conn.cursor()
 cur.execute("DROP TABLE IF EXISTS alembic_version;")

--- a/backend/src/festserve_api/auth.py
+++ b/backend/src/festserve_api/auth.py
@@ -12,7 +12,7 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
 from festserve_api import models
-from festserve_api.database import get_db, Base
+from festserve_api.database import get_db
 
 
 # Secret key for JWT. In production, set via environment variable.
@@ -27,6 +27,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
 
 # Utility functions
 
+
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)
 
@@ -35,8 +36,14 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 
-def authenticate_advertiser(db: Session, email: str, password: str) -> Optional[models.Advertiser]:
-    user = db.query(models.Advertiser).filter(models.Advertiser.contact_email == email).first()
+def authenticate_advertiser(
+    db: Session, email: str, password: str
+) -> Optional[models.Advertiser]:
+    user = (
+        db.query(models.Advertiser)
+        .filter(models.Advertiser.contact_email == email)
+        .first()
+    )
     if not user:
         return None
     if not verify_password(password, user.password_hash):
@@ -44,8 +51,14 @@ def authenticate_advertiser(db: Session, email: str, password: str) -> Optional[
     return user
 
 
-def authenticate_scanner(db: Session, username: str, password: str) -> Optional[models.ScannerUser]:
-    user = db.query(models.ScannerUser).filter(models.ScannerUser.username == username).first()
+def authenticate_scanner(
+    db: Session, username: str, password: str
+) -> Optional[models.ScannerUser]:
+    user = (
+        db.query(models.ScannerUser)
+        .filter(models.ScannerUser.username == username)
+        .first()
+    )
     if not user:
         return None
     if not verify_password(password, user.password_hash):
@@ -53,15 +66,21 @@ def authenticate_scanner(db: Session, username: str, password: str) -> Optional[
     return user
 
 
-def create_access_token(data: dict, expires_delta: Optional[datetime.timedelta] = None) -> str:
+def create_access_token(
+    data: dict, expires_delta: Optional[datetime.timedelta] = None
+) -> str:
     to_encode = data.copy()
-    expire = datetime.datetime.utcnow() + (expires_delta or datetime.timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    expire = datetime.datetime.utcnow() + (
+        expires_delta or datetime.timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
     to_encode.update({"exp": expire})
     token = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return token
 
 
-def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+):
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
@@ -77,20 +96,29 @@ def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(
         raise credentials_exception
     # Choose model based on role
     if role == "advertiser":
-        user = db.query(models.Advertiser).filter(models.Advertiser.advertiser_id == user_id).first()
+        user = (
+            db.query(models.Advertiser)
+            .filter(models.Advertiser.advertiser_id == user_id)
+            .first()
+        )
     else:
-        user = db.query(models.ScannerUser).filter(models.ScannerUser.user_id == user_id).first()
+        user = (
+            db.query(models.ScannerUser)
+            .filter(models.ScannerUser.user_id == user_id)
+            .first()
+        )
     if user is None:
         raise credentials_exception
     return user
 
+
 # Auth router
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
+
 @router.post("/token")
 async def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends(),
-    db: Session = Depends(get_db)
+    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
 ):
     # Determine whether this is an advertiser or scanner login
     # Use form_data.scopes to indicate role: e.g., ["advertiser"] or ["scanner"]
@@ -107,9 +135,13 @@ async def login_for_access_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
     access_token = create_access_token(
-        data={"sub": str(user.advertiser_id if role == "advertiser" else user.user_id), "role": role}
+        data={
+            "sub": str(user.advertiser_id if role == "advertiser" else user.user_id),
+            "role": role,
+        }
     )
     return {"access_token": access_token, "token_type": "bearer"}
+
 
 @router.get("/me")
 async def read_users_me(current_user=Depends(get_current_user)):

--- a/backend/src/festserve_api/create_users.py
+++ b/backend/src/festserve_api/create_users.py
@@ -6,24 +6,26 @@ from festserve_api import models
 
 pwd_ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
+
 def create_users():
     db: Session = SessionLocal()
     # Advertiser
     adv = models.Advertiser(
         name="Test Advertiser",
         contact_email="adv@example.com",
-        password_hash=pwd_ctx.hash("advpassword123")
+        password_hash=pwd_ctx.hash("advpassword123"),
     )
     # Scanner
     scanner = models.ScannerUser(
         username="scanner1",
         password_hash=pwd_ctx.hash("scanpassword123"),
-        assigned_stall_id=None  # assign later or set a valid stall UUID
+        assigned_stall_id=None,  # assign later or set a valid stall UUID
     )
     db.add_all([adv, scanner])
     db.commit()
     print("Created test users")
     db.close()
+
 
 if __name__ == "__main__":
     create_users()

--- a/backend/src/festserve_api/database.py
+++ b/backend/src/festserve_api/database.py
@@ -9,8 +9,7 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 
 # Read the database URL from environment, with a sensible default for Docker Compose
 DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://festserve:festserve@db:5432/festserve"
+    "DATABASE_URL", "postgresql://festserve:festserve@db:5432/festserve"
 )
 
 # Create the SQLAlchemy engine
@@ -30,6 +29,7 @@ SessionLocal = sessionmaker(
 Base = declarative_base()
 
 # Dependency for FastAPI requests
+
 
 def get_db():
     """

--- a/backend/src/festserve_api/health.py
+++ b/backend/src/festserve_api/health.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 health_router = APIRouter()
 
+
 @health_router.get("/healthz")
 def health_check():
     return {"status": "ok"}

--- a/backend/src/festserve_api/main.py
+++ b/backend/src/festserve_api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-#from festserve_api.health import router as health_router
+
+# from festserve_api.health import router as health_router
 from festserve_api.health import health_router
 from festserve_api.auth import router as auth_router
 
@@ -9,9 +10,9 @@ import os
 app = FastAPI()
 
 # Register API routes first
-#app.include_router(health_router, prefix="/api")
+# app.include_router(health_router, prefix="/api")
 app.include_router(health_router, prefix="/api/healthz")
-app.include_router(auth_router) # ← add this line
+app.include_router(auth_router)  # ← add this line
 
 # Mount the built React app at root (this must be last)
 local_static = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../static"))

--- a/backend/src/festserve_api/models.py
+++ b/backend/src/festserve_api/models.py
@@ -1,19 +1,28 @@
-'''
+"""
 SQLAlchemy models and Alembic setup for festserve backend
-'''
+"""
+
 from datetime import datetime
 import enum
 import uuid
 
 from sqlalchemy import (
-    Column, String, Integer, Date, DateTime, Float, Enum, ForeignKey, text, UniqueConstraint
+    Column,
+    String,
+    Integer,
+    Date,
+    DateTime,
+    Float,
+    Enum,
+    ForeignKey,
+    text,
+    UniqueConstraint,
 )
-from passlib.context import CryptContext
 
 from sqlalchemy.dialects.postgresql import UUID
+
 # from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import text
 
 
 # Base = declarative_base()
@@ -21,100 +30,129 @@ from sqlalchemy.sql import text
 # import the shared Base from database.py instead:
 from festserve_api.database import Base
 
+
 # ENUM for campaign status
 class CampaignStatus(str, enum.Enum):
-    scheduled = 'scheduled'
-    active = 'active'
-    completed = 'completed'
+    scheduled = "scheduled"
+    active = "active"
+    completed = "completed"
+
 
 class Advertiser(Base):
-    __tablename__ = 'advertisers'
+    __tablename__ = "advertisers"
     advertiser_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String, nullable=False)
     contact_email = Column(String, nullable=False)
-    password_hash = Column(String, nullable=False)     # ← new
+    password_hash = Column(String, nullable=False)  # ← new
 
-    created_at = Column(DateTime, nullable=False, server_default=text('now()'))
-    campaigns = relationship('Campaign', back_populates='advertiser')
+    created_at = Column(DateTime, nullable=False, server_default=text("now()"))
+    campaigns = relationship("Campaign", back_populates="advertiser")
+
 
 class Stall(Base):
-    __tablename__ = 'stalls'
+    __tablename__ = "stalls"
     stall_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     location_name = Column(String, nullable=False)
     latitude = Column(Float, nullable=False)
     longitude = Column(Float, nullable=False)
     date = Column(Date, nullable=False)
 
-    campaigns = relationship('Campaign', back_populates='stall')
+    campaigns = relationship("Campaign", back_populates="stall")
     __table_args__ = (
-        UniqueConstraint('location_name', 'date', name='uq_stall_location_date'),
+        UniqueConstraint("location_name", "date", name="uq_stall_location_date"),
     )
 
+
 class Product(Base):
-    __tablename__ = 'products'
+    __tablename__ = "products"
     product_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String, nullable=False)
     description = Column(String)
 
-    campaigns = relationship('Campaign', back_populates='product')
+    campaigns = relationship("Campaign", back_populates="product")
+
 
 class ScannerUser(Base):
-    __tablename__ = 'scanner_users'
+    __tablename__ = "scanner_users"
     user_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     username = Column(String, unique=True, nullable=False)
     password_hash = Column(String, nullable=False)
-    assigned_stall_id = Column(UUID(as_uuid=True), ForeignKey('stalls.stall_id'), nullable=True)
-    created_at = Column(DateTime, nullable=False, server_default=text('now()'))
+    assigned_stall_id = Column(
+        UUID(as_uuid=True), ForeignKey("stalls.stall_id"), nullable=True
+    )
+    created_at = Column(DateTime, nullable=False, server_default=text("now()"))
 
-    stall = relationship('Stall')
-    scan_events = relationship('ScanEvent', back_populates='scanner')
+    stall = relationship("Stall")
+    scan_events = relationship("ScanEvent", back_populates="scanner")
+
 
 class Campaign(Base):
-    __tablename__ = 'campaigns'
+    __tablename__ = "campaigns"
     campaign_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    advertiser_id = Column(UUID(as_uuid=True), ForeignKey('advertisers.advertiser_id'), nullable=False)
-    stall_id = Column(UUID(as_uuid=True), ForeignKey('stalls.stall_id'), nullable=False)
-    product_id = Column(UUID(as_uuid=True), ForeignKey('products.product_id'), nullable=False)
+    advertiser_id = Column(
+        UUID(as_uuid=True), ForeignKey("advertisers.advertiser_id"), nullable=False
+    )
+    stall_id = Column(UUID(as_uuid=True), ForeignKey("stalls.stall_id"), nullable=False)
+    product_id = Column(
+        UUID(as_uuid=True), ForeignKey("products.product_id"), nullable=False
+    )
     units_allocated = Column(Integer, nullable=False)
     start_datetime = Column(DateTime, nullable=False)
     end_datetime = Column(DateTime, nullable=False)
-    status = Column(Enum(CampaignStatus), nullable=False, default=CampaignStatus.scheduled)
-
-    advertiser = relationship('Advertiser', back_populates='campaigns')
-    stall = relationship('Stall', back_populates='campaigns')
-    product = relationship('Product', back_populates='campaigns')
-    scan_events = relationship('ScanEvent', back_populates='campaign')
-    snapshots = relationship('ReportingSnapshot', back_populates='campaign')
-
-    __table_args__ = (
-        UniqueConstraint('advertiser_id', 'stall_id', 'product_id', 'start_datetime', name='uq_campaign_unique_run'),
+    status = Column(
+        Enum(CampaignStatus), nullable=False, default=CampaignStatus.scheduled
     )
 
+    advertiser = relationship("Advertiser", back_populates="campaigns")
+    stall = relationship("Stall", back_populates="campaigns")
+    product = relationship("Product", back_populates="campaigns")
+    scan_events = relationship("ScanEvent", back_populates="campaign")
+    snapshots = relationship("ReportingSnapshot", back_populates="campaign")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "advertiser_id",
+            "stall_id",
+            "product_id",
+            "start_datetime",
+            name="uq_campaign_unique_run",
+        ),
+    )
+
+
 class ScanEvent(Base):
-    __tablename__ = 'scan_events'
+    __tablename__ = "scan_events"
     scan_event_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    campaign_id = Column(UUID(as_uuid=True), ForeignKey('campaigns.campaign_id'), nullable=False)
-    scanner_user_id = Column(UUID(as_uuid=True), ForeignKey('scanner_users.user_id'), nullable=False)
+    campaign_id = Column(
+        UUID(as_uuid=True), ForeignKey("campaigns.campaign_id"), nullable=False
+    )
+    scanner_user_id = Column(
+        UUID(as_uuid=True), ForeignKey("scanner_users.user_id"), nullable=False
+    )
     scanned_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     device_fingerprint = Column(String)
 
-    campaign = relationship('Campaign', back_populates='scan_events')
-    scanner = relationship('ScannerUser', back_populates='scan_events')
+    campaign = relationship("Campaign", back_populates="scan_events")
+    scanner = relationship("ScannerUser", back_populates="scan_events")
 
     __table_args__ = (
         # index for fast time-based filtering
-        {'sqlite_autoincrement': True},
+        {"sqlite_autoincrement": True},
     )
 
+
 class ReportingSnapshot(Base):
-    __tablename__ = 'reporting_snapshots'
+    __tablename__ = "reporting_snapshots"
     snapshot_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    campaign_id = Column(UUID(as_uuid=True), ForeignKey('campaigns.campaign_id'), nullable=False)
+    campaign_id = Column(
+        UUID(as_uuid=True), ForeignKey("campaigns.campaign_id"), nullable=False
+    )
     snapshot_time = Column(DateTime, nullable=False, default=datetime.utcnow)
     total_scans = Column(Integer, nullable=False)
     remaining_units = Column(Integer, nullable=False)
 
-    campaign = relationship('Campaign', back_populates='snapshots')
+    campaign = relationship("Campaign", back_populates="snapshots")
+
 
 # Alembic env.py snippet to include metadata
 # in alembic/env.py:


### PR DESCRIPTION
## Summary
- fix Alembic `env.py` to always use `DATABASE_URL` from `database.py`
- tweak migrations for password hash and nullable stall id
- align models with shared Base
- update script for dropping alembic version table
- clean up lint issues

## Testing
- `cd backend && poetry run ruff check .`
- `poetry run black --check .`


------
https://chatgpt.com/codex/tasks/task_e_686ac6701a048327a6c30635c8501aea