### PR TITLE
Update health target path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ dev:
 	docker-compose up --build
 
 health:
-        curl http://localhost:8000/api/healthz
+        curl http://localhost:8000/api/healthz/healthz


### PR DESCRIPTION
## Summary
- update `health` target in Makefile to use `/api/healthz/healthz` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad0332a088327833baa06347eb116