### PR TITLE
Add initial Alembic migration

### DIFF
--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,0 +1,23 @@
+"""Initial migration creating core tables"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from festserve_api.models import Base
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create tables."""
+    bind = op.get_bind()
+    Base.metadata.create_all(bind=bind)
+
+
+def downgrade() -> None:
+    """Drop tables."""
+    bind = op.get_bind()
+    Base.metadata.drop_all(bind=bind)

--- a/backend/alembic/versions/2e446586fcf8_make_scanner_assigned_stall_id_nullable.py
+++ b/backend/alembic/versions/2e446586fcf8_make_scanner_assigned_stall_id_nullable.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "2e446586fcf8"
-down_revision: Union[str, None] = None
+down_revision: Union[str, None] = "0001"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -21,10 +21,8 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.alter_column("scanner_users", "assigned_stall_id", nullable=True)
     """Upgrade schema."""
-    pass
 
 
 def downgrade() -> None:
     op.alter_column("scanner_users", "assigned_stall_id", nullable=False)
     """Downgrade schema."""
-    pass


### PR DESCRIPTION
## Summary
- create a new initial Alembic migration that builds all tables
- link later migrations to the new revision
- remove unused pass statements

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`

------
https://chatgpt.com/codex/tasks/task_e_686ad6a7025c83278c5bdb89fb1724eb