### PR TITLE
Update health endpoints and compose healthcheck

### DIFF
--- a/backend/src/festserve_api/health.py
+++ b/backend/src/festserve_api/health.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter
 
-health_router = APIRouter()
+health_router = APIRouter(prefix="/healthz")
 
 
-@health_router.get("/healthz")
+@health_router.get("/")
 def health_check():
     return {"status": "ok"}

--- a/backend/src/festserve_api/main.py
+++ b/backend/src/festserve_api/main.py
@@ -10,8 +10,7 @@ import os
 app = FastAPI()
 
 # Register API routes first
-# app.include_router(health_router, prefix="/api")
-app.include_router(health_router, prefix="/api/healthz")
+app.include_router(health_router, prefix="/api")
 app.include_router(auth_router)  # ← add this line
 
 # Mount the built React app at root (this must be last)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,7 @@ services:
     depends_on:
       - db
     healthcheck:
-      # test: ["CMD", "curl", "-f", "http://localhost:8000/api/healthz"]
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/healthz/healthz"]
-
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- configure the health router with a prefix
- mount health router under `/api`
- adjust docker-compose healthcheck path

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_686c108f8a988327963cacf49269a740