### PR TITLE
Fix deprecation warnings in API routes

### DIFF
--- a/backend/src/festserve_api/routes/campaigns.py
+++ b/backend/src/festserve_api/routes/campaigns.py
@@ -150,7 +150,7 @@ def update_campaign(
         raise HTTPException(status_code=404, detail="Campaign not found")
 
     # apply any provided fields
-    for field, value in payload.dict(exclude_unset=True).items():
+    for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(campaign, field, value)
 
     db.commit()

--- a/backend/src/festserve_api/routes/products.py
+++ b/backend/src/festserve_api/routes/products.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/api/products", tags=["products"])
 
 @router.post("/", response_model=schemas.ProductRead, status_code=status.HTTP_201_CREATED)
 def create_product(payload: schemas.ProductCreate, db: Session = Depends(get_db)):
-    product = models.Product(**payload.dict())
+    product = models.Product(**payload.model_dump())
     db.add(product)
     db.commit()
     db.refresh(product)

--- a/backend/src/festserve_api/routes/stalls.py
+++ b/backend/src/festserve_api/routes/stalls.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/api/stalls", tags=["stalls"])
 
 @router.post("/", response_model=schemas.StallRead, status_code=status.HTTP_201_CREATED)
 def create_stall(payload: schemas.StallCreate, db: Session = Depends(get_db)):
-    stall = models.Stall(**payload.dict())
+    stall = models.Stall(**payload.model_dump())
     db.add(stall)
     db.commit()
     db.refresh(stall)

--- a/backend/src/festserve_api/schemas.py
+++ b/backend/src/festserve_api/schemas.py
@@ -18,7 +18,7 @@ class CampaignRead(BaseModel):
     status: str
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class CampaignUpdate(BaseModel):
@@ -28,7 +28,7 @@ class CampaignUpdate(BaseModel):
     status: str | None = None
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class ScanEventCreate(BaseModel):
@@ -43,7 +43,7 @@ class ScanEventRead(BaseModel):
     device_fingerprint: str | None
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class StallCreate(BaseModel):
@@ -57,7 +57,7 @@ class StallRead(StallCreate):
     stall_id: UUID4
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class ProductCreate(BaseModel):
@@ -69,7 +69,7 @@ class ProductRead(ProductCreate):
     product_id: UUID4
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 class SnapshotRead(BaseModel):
     snapshot_id: UUID4
@@ -79,4 +79,4 @@ class SnapshotRead(BaseModel):
     remaining_units: int
 
     class Config:
-        orm_mode = True
+        from_attributes = True


### PR DESCRIPTION
## Summary
- update API routes to use `model_dump()` instead of deprecated `dict()`
- switch pydantic models from `orm_mode` to `from_attributes`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ddc11b1688327b2c616e82591c9c1