### PR TITLE
Add basic React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Run the following inside the `backend/` directory:
 poetry install --no-root
 poetry run pytest
 ```
+
+## Running the frontend
+Inside the `frontend/` directory install dependencies and start the dev server:
+```bash
+npm install
+npm run dev
+```
+The application will be served on `http://localhost:5173`.
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.20.1"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.28.0",
@@ -1133,6 +1134,15 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/estree": {
@@ -3567,6 +3577,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.20.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.28.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,26 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from 'react-router-dom';
+import Login from './pages/Login';
+import CampaignList from './pages/CampaignList';
 
 function App() {
+  const token = localStorage.getItem('token');
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold">FestServe Frontend</h1>
-      <p>Your PWA will live here.</p>
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/"
+          element={token ? <CampaignList /> : <Navigate to="/login" replace />}
+        />
+      </Routes>
+    </Router>
   );
 }
 

--- a/frontend/src/pages/CampaignList.jsx
+++ b/frontend/src/pages/CampaignList.jsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+function CampaignList() {
+  const [campaigns, setCampaigns] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch('/api/campaigns', {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+      });
+      if (res.ok) {
+        setCampaigns(await res.json());
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Campaigns</h1>
+      <ul>
+        {campaigns.map((c) => (
+          <li key={c.campaign_id}>{c.product_id} - {c.units_allocated}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default CampaignList;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    try {
+      const body = new URLSearchParams();
+      body.append('username', email);
+      body.append('password', password);
+      body.append('scope', 'advertiser');
+
+      const res = await fetch('/api/auth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+      if (!res.ok) {
+        throw new Error('Login failed');
+      }
+      const data = await res.json();
+      localStorage.setItem('token', data.access_token);
+      window.location.href = '/';
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <button type="submit">Login</button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+}
+
+export default Login;


### PR DESCRIPTION
## Summary
- build simple React login and campaign listing pages
- enable routing in `App.jsx`
- add `react-router-dom` dependency
- document how to run the frontend

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880912b15a88327806262528924720b